### PR TITLE
Add article on Unix Spell's memory-efficient design

### DIFF
--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -43,3 +43,25 @@
 * By working with hash differences, the differences were smaller than the raw hash codes, and thus, more memory efficient
   * Difference values would repeat leading to more effective compression
 * Finding a hash code meant starting with the first hash code, and then adding each of the differences until the matching hash code was identified
+* One of the basic principles behind lossless compression is to assign shorter codes to symbols with higher probabilities and longer codes to symbols with lower probabilities
+  * Requires computing the probability distribution of all the symbols in the data set
+* Holding a probability distribution table for 30k symbols in memory would eliminate any compression advantage from this hash-based approach
+* Computing the hash difference probabilities would not have been possible to do in-memory, so an expensive disk-based solution would have been necessary to compute these probabilities
+
+## Encoding Algorithm
+* Hash difference values follow a pattern of exponential decay
+* Segment the hash difference values into blocks of size `m`
+* Each value within a block is assigned a code of `k` bits
+* The next block gets codes of size `k + 1` bits
+* The minimum number of bits required to encode the outcome of an event is calculated by its information content - `-log (probability of an event)`
+* If the event has a `1/2` probability, it needs a `1` bit code, an event with probability `1/4` needs `2` bits, etc
+
+### Example
+* The block size is `5` and the codes in the first block are `4` bits wide (starting `k` is `4`)
+* First code in the first block is `0110`
+* Next four block codes are `0111`, `1000`, `1001`, `1010`
+* The next block (block `2`) would naturally start at `1011` (`1` + the last code in block 1 (`1010`))
+* However, since this code is in the next block, its bit width needs to be `1` bit larger
+* So left bit shift `1011` to `10110`
+* Note that the last `4` bits of `10110` are the same as the first code in the first block (`0110`)
+

--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -65,3 +65,40 @@
 * So left bit shift `1011` to `10110`
 * Note that the last `4` bits of `10110` are the same as the first code in the first block (`0110`)
 
+### Bit Width of the Codes
+* Assume the first encoded value in the first block is `2x`
+* First code of the second block _should be_ `2x + m`
+  * Because codes in the next block need to be `1` bit wider, the value gets shifted to the left by `1` bit
+  * Left shifting a value by `1` bit doubles it, so the value is `2(2x + m)`
+  * `2(2x + m)` is also the same as `2^k + 2x` since adding a bit at the `k`th position from the right is equivalent to adding `2^k`
+* Can solve for `k` to get the code width of the first block
+* Can also solve for `x`
+
+## Back to the Encoding Algorithm
+```python
+def encode(value):
+    # Case 1: Values less than x
+    # These get shorter codes of length k-1
+    # Because we have unused bit patterns available
+    if value < x:
+        return value, k-1  # return (code, length)
+    
+    # Case 2: Values >= x
+    # Need to find which block they belong to
+    value = value - x     # adjust relative to first code
+    y = 1                 # tracks block number through bit shifts
+    length = k           # start with k bits
+    
+    # Find block by repeatedly subtracting block size
+    while value >= m:    # m is block size
+        value -= m       # move to next block
+        y = y << 1      # add padding bit for next block
+        length += 1     # each block needs one more bit
+    
+    # Generate final code:
+    # (y-1) << k creates padding bits based on block number
+    # x*2 adds offset for the first code
+    # value adds position within current block
+    code = ((y-1) << k) + (x*2) + value
+    return code, length
+```

--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -74,7 +74,7 @@
 * Can solve for `k` to get the code width of the first block
 * Can also solve for `x`
 
-## Back to the Encoding Algorithm
+### Back to the Encoding Algorithm
 ```python
 def encode(value):
     # Case 1: Values less than x
@@ -102,3 +102,19 @@ def encode(value):
     code = ((y-1) << k) + (x*2) + value
     return code, length
 ```
+
+## The Decoding Algorithm
+* Look at the top `k-1` bits
+* If the value represented by these bits is less than `x`, then the decoded value is the value represented by the `k-1` bits
+* If the value represented by these bits is >= `x`
+  * Then include one more bit in this value
+  * Look at the least significant `k` bits
+  * If the value represented by these `k` bits is < `2x + m`
+    * then the decoded value is `x + value represented by k bits + ((# of extra bits that are in the top k - 1 bits) - 1) * m`
+    * otherwise keep including more bits until the `k` least significant bits is < `2x + m`
+
+## Efficiency
+* These codes managed to achieve an expected code length of `13.6` bits which is very close to the theoretical compression limit of `13.57`
+* Runtime performance was slow because to lookup a value, the dictionary needed to be decoded starting from the beginning of the dictionary
+* Partitioning was added to split this table of differences into `M` bins so that the correct bin was located first, and then scanned
+  * Partitioning required storing additional pointers to each bin, adding `log M` bits per word

--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -24,3 +24,11 @@
   * Based on a fixed dictionary of 25,000 items, and a bit table size of 400k bits (due to limited RAM), they used 11 hash functions to achieve this false positive rate
 * However, they kept finding words to add to the dictionary, so the dictionary size kept increasing (went from 25,000 to 30,000)
   * A bigger dictionary required a larger bit table, which was not possible from a memory perspective
+
+## Compressed Hashing Scheme for Dictionary Lookups
+* Stored the _hashes_ of the words in a hash table
+* While individual words can vary in length, the hash function should compress these words into a fixed number of bits
+* In order to handle hash collisions, the hash code needs to be long enough to support the minimum acceptable collision tolerance
+* A hash code of size `b` bits has a total hash code space of `2 ^ b` hash codes
+* If the size of the dictionary is `V`, then the probability of a hash collision is `V / (2 ^ b)`
+* Given that a collision rate of `1/(2 ^ 12)` was acceptable, a hash code size of `27` bits is needed

--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -1,0 +1,26 @@
+# [How Unix Spell Ran in 64kB RAM](https://blog.codingconfessions.com/p/how-unix-spell-ran-in-64kb-ram)
+* The spell checker for unix needed to fit a 250 KB dictionary in 64 KB of RAM while still performing fast lookups
+  * Even with modern compression techniques, a 250 KB file could not be compressed to less than 85 KB
+
+## Affix Removal Algorithm
+* Iteratively remove common prefixes and suffixes from a word
+* Look up these progressive word fragments to see if they are present in the dictionary
+* `misrepresented` -> `present` (which is in dictionary) by removing prefixes `mis`, `re` and suffix `ed`
+* This algorithm was not 100% accurate (misspelled words were not always identified)
+* Because of the usage of this algorithm, the final dictionary could contain much less information than the original 250 KB dictionary
+  * Final dictionary consisted of 25,000 words
+
+## A Bloom Filter-based Lookup
+* Still not possible to load the 25,000 word dictionary into 64 KB of RAM
+* Bloom filter is a bit table (initialized to all `0`s)
+* To add an item to this bit table, apply `k` hash functions to the item
+  * Hash functions should return a value representing an index in the bit table
+  * Flip the bit at each returned index value in the bit table to `1`
+* To look up an item to see if it might exist in the Bloom filter, reverse the process
+  * Apply the `k` hash functions to the lookup item and see if the corresponding value index is set to `1` in the bit table
+  * If at least one of returned bit table values is `0`, then the item is definitely not present
+  * If all the returned bit table values is `1`, then the item _might_ be present due to hash collisions
+* A false positive rate of 1 in 2000 was acceptable
+  * Based on a fixed dictionary of 25,000 items, and a bit table size of 400k bits (due to limited RAM), they used 11 hash functions to achieve this false positive rate
+* However, they kept finding words to add to the dictionary, so the dictionary size kept increasing (went from 25,000 to 30,000)
+  * A bigger dictionary required a larger bit table, which was not possible from a memory perspective

--- a/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
+++ b/Software Engineering/Computers/Operating Systems/Linux/blog.codingconfessions.com/How Unix Spell Ran in 64kB RAM.md
@@ -32,3 +32,14 @@
 * A hash code of size `b` bits has a total hash code space of `2 ^ b` hash codes
 * If the size of the dictionary is `V`, then the probability of a hash collision is `V / (2 ^ b)`
 * Given that a collision rate of `1/(2 ^ 12)` was acceptable, a hash code size of `27` bits is needed
+
+## The Theoretical Minimum Limit of Hash Code Compression
+* The probability of an event and the bits needed to encode it are related
+* A 100% probable event needs no information to be stored (i.e. 0 bits are necessary to encode it)
+* Given some math, and given a dictionary size of `30,000` words the minimum number of bits needed to encode a single hash code is `~14` bits, which is `~50%` less than the original `27` bit hash code
+
+## Delta-Based Compression Scheme
+* Instead of compressing raw hash codes, they computed and stored differences between successive hash codes, stored in sorted order
+* By working with hash differences, the differences were smaller than the raw hash codes, and thus, more memory efficient
+  * Difference values would repeat leading to more effective compression
+* Finding a hash code meant starting with the first hash code, and then adding each of the differences until the matching hash code was identified


### PR DESCRIPTION
Documented the algorithm and techniques used by Unix Spell to run within 64 KB of RAM, including affix removal and Bloom filter-based lookup.